### PR TITLE
Register zero reopen pop strategy in entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 ![CI](https://github.com/yoyowasa/BFMMBOT/actions/workflows/ci.yml/badge.svg)
+
+- [CODEX: Zero→Reopen Pop（スプレッド0→再拡大の1拍だけ取る戦略）](docs/CODEX_ZERO_REOPEN_POP.md)  <!-- 何をするか：戦略の詳細仕様と運用ワークフローの導線 -->

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -40,6 +40,12 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
   tiny_prints_N: 20        # Tiny-Prints集計N（OFFの初期値）
   tiny_prints_minCount: 14 # Tiny-Prints発火閾値（OFFの初期値）
   eta_t_window_ms: 800     # Queue ETAの窓（OFFの初期値）
+  zero_reopen_pop:  # 何をする設定か：ゼロ→再拡大の“一拍だけ”出す戦略のパラメータ
+    min_spread_tick: 1         # 何をする設定か：再拡大の下限tick（1以上で発注可）
+    ttl_ms: 800                # 何をする設定か：指値の寿命ms（置きっぱなし防止）
+    size_min: 0.001            # 何をする設定か：最小ロット（取引所の最小単位に合わせる）
+    cooloff_ms: 250            # 何をする設定か：連打を防ぐ冷却時間ms
+    seen_zero_window_ms: 1000  # 何をする設定か：ゼロを“直後”とみなす時間窓ms
 
 strategies:  # まずは2本だけON（他はOFF）
   - stall_then_strike  # #1 静止→一撃

--- a/docs/CODEX_ZERO_REOPEN_POP.md
+++ b/docs/CODEX_ZERO_REOPEN_POP.md
@@ -1,0 +1,228 @@
+# CODEX: Zero→Reopen Pop（スプレッド一瞬0→再拡大の1拍だけ取る）
+
+## 1. 要約（小学生にもわかる説明）
+- **ドア（スプレッド）が一瞬ピタッと閉じる＝0**になったあと、**すぐ“少しだけ開いた”瞬間**だけ1回だけ手を出して、**当たったら1段（+1tick）で逃げる**作戦です。
+- ふだんは**何もしない**で待ち、**合図が出た“数百msだけ”**片面に**最小ロット**を置いて**秒速で利確IOC**します（常時両面を出し続ける“普通のMM”ではありません）。
+
+---
+
+## 2. 背景と前提
+- **データ源**：bitFlyer Lightning のリアルタイム **board / executions**（WS）。  
+  チャネル：`lightning_board_*` / `lightning_executions_*`（FX_BTC_JPY を想定）。  
+  指値は GTC / IOC / FOK 利用可（TTLはローカル管理で実装）。  
+- **ねらい**：**「スプレッド=0 → 直後に≥1tickへ再拡大」**という**離散イベント**だけを合図に、**毒性の低い瞬間**を薄く拾う。  
+- **運用**：標準のガードレール（在庫・PnL・DD・mid急変・メンテ/ファンディング窓）に**完全準拠**。  
+
+---
+
+## 3. ロジック仕様（詳細）
+
+### 3.1 シグナル（合図）
+1) **ゼロ検知**：`spread_tick == 0` を検出した**時刻 t0 を記録**する。  
+2) **再拡大確認**：t0 から **1秒以内**に `spread_tick >= 1` へ戻ったら **候補オン**。  
+3) **安全ゲート**（いずれも満たすときだけ発注）  
+   - **health_ok()**：既存の鮮度・在庫・スプレッド上限・Kill等のヘルスチェックがOK。  
+   - **cooloff_ms 経過**：直近アクションからの冷却を満たす（連打・毒性回避）。  
+   - **TTL運用**：置いた指値は短寿命（700–900ms）で自然に剥がす前提。
+
+### 3.2 エントリー（どちら側に置く？）
+- 直感：**再拡大の“外側”で、逆向きに1tick待つ。**  
+- 実装簡便案：  
+  `place_buy = (best_ask - mid) >= (mid - best_bid)`  
+  - `place_buy == True` → **BUY** を **mid−1tick** に最小ロットでGTC+TTL。  
+  - `False` → **SELL** を **mid+1tick** に最小ロットでGTC+TTL。  
+- **タグ**：`tag="zero_reopen"`（後続のログ/AB判定で識別可能に）。
+
+### 3.3 利確（秒速で逃げる）
+- **約定 fill を受けたら即時**、反対側 **±1tick** に **IOC** を1発（`tag="zero_reopen_take"`）。  
+- IOCが不成立でも **TTLとガード**で自然に剥がす／撤退条件で即取消。
+
+### 3.4 撤退（やめる合図）
+- **再クロス（再び spread=0）**／**Best更新**／**TTL超過**／**health_ok() 失効** → **即撤退**。  
+- 在庫上限やKillスイッチなど**上位リスク制御**が優先。
+
+---
+
+## 4. パラメータ（初期値の目安）
+- `min_spread_tick = 1`（再拡大の下限）  
+- `ttl_ms = 700–900`（素早い自然キャンセル）  
+- `size_min = 取引所最小ロット`（まずは極小）  
+- `cooloff_ms = 250`（連打禁止・毒性回避）  
+（YAMLの `features.zero_reopen_pop.*` へ**外出し推奨**）
+
+---
+
+## 5. ワークフロー（イベント→意思決定→発注→利確→撤退）
+
+1) **Board受信**：差分をローカル板へ適用。`spread_tick`/`best_bid/ask`/`mid` を更新。  
+2) **ゼロ検知**：`spread_tick==0` で `last_spread_zero_ms ← now`。  
+3) **再拡大チェック**：`now - last_spread_zero_ms ≤ 1000ms` かつ `spread_tick ≥ 1` で候補オン。  
+4) **安全ゲート**：`health_ok()==True` かつ `now - last_action_ms ≥ cooloff_ms` を確認。  
+5) **サイド決定**：上記の簡便判定で **BUY@mid−1tick** または **SELL@mid+1tick** を選ぶ。  
+6) **発注**：**最小ロット**・**GTC+TTL**・`tag="zero_reopen"` で片面1枚だけ置く。  
+7) **ログ**：意思決定時に `spread_state / ttl_ms / cooloff_ms / side / px / expected_edge` を記録。  
+8) **利確**：**fill** を受けたら**即IOC**で ±1tick に出して**秒速撤退**。  
+9) **撤退**：Best更新／再クロス／TTL超過／ガード失効 → **取消**。  
+10) **メトリクス**：`win_rate(+5〜10s後)/adverse_move_P95/fill_ratio` を日次で集計。  
+
+---
+
+## 6. 関数と責務（1行で“何をするか”を固定）
+
+- **【関数】spread_state.update**  
+  役割：`spread_tick==0` を検知した時刻を記録し、**“ゼロ直後”**かどうかを判定できる状態を保つ。
+
+- **【関数】signal.zero_reopen_ready**  
+  役割：**ゼロ直後 & 再拡大≥1tick & safety全OK & クールオフ済み**を満たすかを真偽で返す。
+
+- **【関数】decision.pick_side_and_price**  
+  役割：再拡大の“外側”で**逆向き1tick**の指値価格とサイド（BUY/SELL）を決める。
+
+- **【関数】orders.place_zero_reopen**  
+  役割：**最小ロット**で **GTC+TTL** の片面指値を一発だけ出す（`tag="zero_reopen"`）。
+
+- **【関数】fills.on_zero_reopen_fill**  
+  役割：fill受信で**即IOC**の±1tick利確を返す（`tag="zero_reopen_take"`）。
+
+- **【関数】guards.health_ok**  
+  役割：鮮度/在庫/スプ上限/モード（Healthy/Caution/Halted）等の**標準ガード**を一括判定。
+
+- **【関数】logging.decision_log**  
+  役割：合図・価格・TTL・cooloff・side・px・想定エッジ等を1行で**意思決定ログ**へ書く。
+
+---
+
+## 7. ログと運用（Codexに載せる約束ごと）
+
+- **注文ログ**：`ts, action(place/cancel/fill), tif, ttl_ms, px, sz, reason`（タグで戦略識別）。  
+- **トレードログ**：`ts, side, px, sz, fee, pnl, strategy, tag, inventory_after`。  
+- **意思決定ログ**：`ts, strategy, features_json(spread_state等), decision, expected_edge_bp`。  
+- **運用ガード**：mid30s変化率、在庫上限、日次DD、メンテ/ファンディング窓で**自動停止/縮小**。  
+- **AB導入**：この戦略は“合図が少ない”ため**A/B比較が容易**。ヒット率・逆行P95で効果検証する。
+
+---
+
+## 8. 失敗パターン（やってはいけない振る舞い）
+- TTLを長くして**置きっぱなし**にする（→普通のMM化）。  
+- 合図が無いのに**常時両面**を置く。  
+- ガード/モード（Caution/Halted）を**無視**して出し続ける。  
+→ いずれも**毒性上昇**で期待値が崩れます。“**合図が重なる瞬間だけ**薄く出す”が正解。
+
+---
+
+## 9. バックテスト（録画リプレイの最短レシピ）
+1) WSテープ（NDJSON）を再生し、**ゼロ→再拡大**のヒット時刻を列挙。  
+2) 同じ箇所で TTL・ガード・利確IOC を適用し、**勝率(+5〜10s)**・**逆行P95**・**手数料後PnL**を集計。  
+3) **A/B**：ガード閾値（cooloff/ttl/min_spread_tick）を“数字だけ”調整し、毒性を最小化する。
+
+---
+
+## 10. 起動・停止の型（運用者ポケットガイド）
+- **起動**：復元→初回整合→WS購読→**ウォームアップ（連続OKでHealthy）**の順。  
+- **停止**：新規停止（Halted）→キュー吐き切り→最終整合→スナップ保存→WSクローズ。  
+- **異常時**：**Halted（決済のみ許可）→整合チェック→HTTPリプレイ→復帰**を最優先に。
+
+参考・根拠（設計と運用の出典）
+
+戦略リスト/Zero→Reopenの骨子・WSチャンネル/TIF可用性（bitFlyer MMボット戦略の設計メモ）。
+
+CFD向けフル構成/ログ仕様/CLI・設定・ロジック仕様（#7 Zero→Reopenを含む）/運用ワークフロー。
+
+在庫“自炊”ワークフロー：WS→キュー→適用→整合→永続化→アラートの基本線（引継ぎ用の手順集）。
+
+ロールアウト/多段導入・障害対応・安全装置（Caution/Halted）の運用規約。
+
+バックテスト/リプレイ検証・設定外出し・EOD・SLO/SLAの物差し。
+
+## 11. 擬似コード（I/O定義と主要分岐）
+
+### インターフェース（受け取り・返し）
+# Order: {side: "BUY"/"SELL", price: float, size: float, tif: "GTC"/"IOC", ttl_ms: int, tag: str}
+# OrderbookView: best_bid(), best_ask(), mid_price(), tick_size(), spread_ticks(), health_ok()
+# Fill: {side: "BUY"/"SELL", price: float, size: float, tag: str}
+# Time: now_ms(): int
+
+# 設定（外だし想定）
+struct Config {
+  min_spread_tick: int = 1
+  ttl_ms: int = 800
+  size_min: float = 0.001
+  cooloff_ms: int = 250
+  seen_zero_window_ms: int = 1000
+}
+
+# 内部状態
+struct State {
+  last_spread_zero_ms: int = -INF   # 【何をするか】直近にspread==0を見た時刻を記録する
+  last_action_ms: int = -INF        # 【何をするか】連打防止の冷却起点を記録する
+}
+
+# 【関数】mark_zero(ob, now, state) -> None
+# 何をする：spread==0を見た時刻を記録して“直後”判定を可能にする
+if ob.spread_ticks() == 0:
+  state.last_spread_zero_ms = now
+  return
+
+# 【関数】is_reopen(ob, now, state, cfg) -> Bool
+# 何をする：直近にゼロがあり、現在は再拡大（>=min_spread_tick）かを判定する
+seen_zero_recently = (now - state.last_spread_zero_ms) <= cfg.seen_zero_window_ms
+return seen_zero_recently and (ob.spread_ticks() >= cfg.min_spread_tick)
+
+# 【関数】pass_gates(ob, now, state, cfg) -> Bool
+# 何をする：標準ガードとクールダウンをまとめて判定する
+if not ob.health_ok(): return False
+if (now - state.last_action_ms) < cfg.cooloff_ms: return False
+if ob.best_bid() is None or ob.best_ask() is None: return False
+return True
+
+# 【関数】choose_side(ob) -> ("BUY"|"SELL")
+# 何をする：ミッドに対するbestのズレから、逆向きに1tick待つ側を決める
+mid = ob.mid_price()
+bid = ob.best_bid()
+ask = ob.best_ask()
+if (ask - mid) >= (mid - bid): return "BUY"
+else: return "SELL"
+
+# 【関数】build_entry(ob, side, cfg) -> Order
+# 何をする：片面1発の指値（GTC+TTL、最小ロット、tag付）を生成する
+tick = ob.tick_size()
+mid = ob.mid_price()
+if side == "BUY": px = mid - tick
+else: px = mid + tick
+return Order(side=side, price=px, size=cfg.size_min, tif="GTC", ttl_ms=cfg.ttl_ms, tag="zero_reopen")
+
+# 【関数】build_take_profit(ob, fill) -> Order
+# 何をする：+1tickのIOC利確を即時生成して秒速撤退する
+tick = ob.tick_size()
+if fill.side == "BUY": px = fill.price + tick; out_side = "SELL"
+else: px = fill.price - tick; out_side = "BUY"
+return Order(side=out_side, price=px, size=fill.size, tif="IOC", ttl_ms=200, tag="zero_reopen_take")
+
+# 【関数】should_cancel(ob, now, placed_at_ms, state, cfg) -> Bool
+# 何をする：条件喪失/TTL超過/再クロス/ガード失効を検出して取消要否を返す
+if not ob.health_ok(): return True
+if ob.spread_ticks() == 0: return True
+if (now - placed_at_ms) > cfg.ttl_ms: return True
+return False
+
+# 【関数】on_board(ob, now, state, cfg) -> List[Order]
+# 何をする：板イベントで、ゼロ記録→再拡大＆ゲート合格なら1枚だけ返す
+mark_zero(ob, now, state)
+if is_reopen(ob, now, state, cfg) and pass_gates(ob, now, state, cfg):
+  side = choose_side(ob)
+  order = build_entry(ob, side, cfg)
+  state.last_action_ms = now
+  return [order]
+return []
+
+# 【関数】on_fill(ob, fill, cfg) -> List[Order]
+# 何をする：fill受信で+1tickのIOCを即返して利確する
+return [build_take_profit(ob, fill)]
+
+# 【関数】periodic_check(ob, now, open_orders, state, cfg) -> List[cancel_ids]
+# 何をする：開いている“zero_reopen”タグ注文をshould_cancelで順次キャンセルする
+cancels = []
+for oid, placed_at_ms, tag in open_orders:
+  if tag == "zero_reopen" and should_cancel(ob, now, placed_at_ms, state, cfg):
+    cancels.append(oid)
+return cancels

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -16,6 +16,7 @@ from src.core.simulator import MiniSimulator  # 最小シミュ（本ステッ�
 from src.strategy.stall_then_strike import StallThenStrike  # 戦略#1（本ステップ）
 from src.strategy.age_microprice import AgeMicroprice  # #3 エイジ×MPを選べるようにする
 from src.strategy.cancel_add_gate import CancelAddGate  # #2 キャンセル比ゲートを選べるようにする
+from src.strategy.zero_reopen_pop import ZeroReopenPop  # ゼロ→再拡大“一拍”だけ片面+即IOC利確を選べるようにする
 
 def _parse_iso(ts: str) -> datetime:
     """【関数】ISO文字列→datetime（'Z' を +00:00 に）"""
@@ -40,6 +41,8 @@ def run_backtest_min(cfg, tape_path: str, strategy_name: str = "stall_then_strik
         strat = CancelAddGate()
     elif strategy_name == "age_microprice":
         strat = AgeMicroprice()
+    elif strategy_name == "zero_reopen_pop":
+        strat = ZeroReopenPop()
     else:
         strat = StallThenStrike()
 

--- a/src/cli/trade.py
+++ b/src/cli/trade.py
@@ -29,8 +29,8 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run paper trading (real-time)")
     p.add_argument("--config", required=True, help="configs/paper.yml など")
     p.add_argument("--strategy", default="stall_then_strike",
-                choices=["stall_then_strike", "cancel_add_gate", "age_microprice"],
-                help="どの戦略で動かすか（#1/#2/#3）")
+                choices=["stall_then_strike", "cancel_add_gate", "age_microprice", "zero_reopen_pop"],
+                help="どの戦略で動かすか（#1/#2/#3/#4）")
     p.add_argument("--dry-run", action="store_true", help="何をするか：liveでも実発注せず疎通確認だけ行う（安全テスト）")
     p.add_argument("--paper", action="store_true", help="何をするか：取引所へ発注せず、板に当たれば fills をシミュレートする")
 

--- a/src/runtime/engine.py
+++ b/src/runtime/engine.py
@@ -21,6 +21,7 @@ from src.core.analytics import DecisionLog  # 【関数】意思決定ログ（P
 from src.strategy.stall_then_strike import StallThenStrike  # #1 静止→一撃（ON）:contentReference[oaicite:7]{index=7}
 from src.strategy.cancel_add_gate import CancelAddGate  # #2 キャンセル比ゲート（ON）:contentReference[oaicite:8]{index=8}
 from src.strategy.age_microprice import AgeMicroprice  # #3 エイジ×MP
+from src.strategy.zero_reopen_pop import ZeroReopenPop  # ゼロ→再拡大“一拍”だけ片面+即IOC利確
 
 def _parse_iso(ts: str) -> datetime:
     """【関数】ISO→datetime（'Z'も+00:00に正規化）"""
@@ -53,6 +54,8 @@ class PaperEngine:
             self.strat = CancelAddGate()
         elif strategy_name == "age_microprice":
             self.strat = AgeMicroprice()
+        elif strategy_name == "zero_reopen_pop":
+            self.strat = ZeroReopenPop()
         else:
             self.strat = StallThenStrike()
 

--- a/src/runtime/live.py
+++ b/src/runtime/live.py
@@ -34,6 +34,7 @@ from src.core.realtime import stream_events  # 何をするか：WSのboard/exec
 from src.strategy.stall_then_strike import StallThenStrike  # 何をするか：#1 戦略
 from src.strategy.cancel_add_gate import CancelAddGate  # 何をするか：#2 戦略
 from src.strategy.age_microprice import AgeMicroprice  # 何をするか：#3 戦略
+from src.strategy.zero_reopen_pop import ZeroReopenPop  # 何をするか：ゼロ→再拡大“一拍”だけ片面+即IOC利確の戦略
 from src.core.logs import OrderLog, TradeLog  # 何をするか：orders/trades を Parquet＋NDJSON に記録する
 from src.core.analytics import DecisionLog  # 何をするか：戦略の意思決定ログ（Parquet＋NDJSONミラー）を扱う
 
@@ -51,6 +52,8 @@ def _select_strategy(name: str, cfg):
     if name == "age_microprice":
         try: return AgeMicroprice(cfg)
         except TypeError: return AgeMicroprice()
+    if name == "zero_reopen_pop":
+        return ZeroReopenPop()
     raise ValueError(f"unknown strategy: {name}")
 
 def _now_utc() -> datetime:

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -1,3 +1,25 @@
 """strategy パッケージの初期化
 - 役割: 戦略プラグイン（#1〜#7）を入れる箱
 """
+
+# 何をするimportか：エントリーポイント（CLI/ランタイム）から戦略クラスを取り出せるようにする
+from .stall_then_strike import StallThenStrike  # 何をするか：#1 静止→一撃（Best静止後にミッド±1tick両面を置く）
+from .cancel_add_gate import CancelAddGate    # 何をするか：#2 キャンセル比ゲート（落ち着いた瞬間だけ片面提示）
+from .age_microprice import AgeMicroprice     # 何をするか：#3 エイジ×マイクロプライス（Age×MPで片面提示）
+from .zero_reopen_pop import ZeroReopenPop    # 何をするか：ゼロ→再拡大の“一拍”だけ狙うワンショットMMのクラスを読み込む
+
+# 何をする定義か：戦略名→クラスの対応表（CLI --strategy などから参照）
+STRATEGY_REGISTRY = {
+    "stall_then_strike": StallThenStrike,  # 何をするか：Best静止→ミッド±1tick両面を置く戦略を登録
+    "cancel_add_gate": CancelAddGate,      # 何をするか：C/A比ゲートで落ち着いた瞬間だけ片面提示する戦略を登録
+    "age_microprice": AgeMicroprice,      # 何をするか：MP偏りとBest Ageで片面提示する戦略を登録
+    "zero_reopen_pop": ZeroReopenPop,     # 何をするか：spread==0直後の再拡大に片面1tick→当たったら即+1tick利確の戦略を登録
+}
+
+__all__ = [
+    "StallThenStrike",
+    "CancelAddGate",
+    "AgeMicroprice",
+    "ZeroReopenPop",
+    "STRATEGY_REGISTRY",
+]

--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -1,0 +1,130 @@
+# 何をするモジュールか：
+#   「スプレッドが一瞬0になった直後、1tick以上に再拡大した“その一拍”だけ」片面で最小ロットを置き、
+#   当たったら即IOCで+1tick利確して退出する“イベント駆動ワンショットMM”の本体実装。
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+# 何をするimportか：戦略の骨組み・板の読み取り・注文生成・時刻取得（すべて既存の共通層を利用）
+from src.strategy.base import StrategyBase
+from src.core.orderbook import OrderbookView  # best/中値/tick/スプレッド/健全性 health_ok() を提供
+from src.core.orders import Order, TIF        # Limit/IOC と TTL/タグを付けて発注する型
+from src.core.utils import now_ms             # クールダウンや“直後”判定に使うミリ秒時刻
+
+
+@dataclass
+class ZeroReopenConfig:
+    """何をする設定か：最小限の外だしパラメータ（YAML上書き前提）"""
+
+    min_spread_tick: int = 1       # 再拡大の下限（1tick以上に開いていること）
+    ttl_ms: int = 800              # 指値の寿命（置きっぱなし防止・秒速撤退のため短め）
+    size_min: float = 0.001        # 最小ロット（取引所の最小単位に合わせる）
+    cooloff_ms: int = 250          # 連打禁止と毒性回避のための“息継ぎ”
+    seen_zero_window_ms: int = 1000  # どれだけ“ゼロ直後”を有効とみなすか
+
+
+class ZeroReopenPop(StrategyBase):
+    """
+    何をする戦略か：
+      - 直近に spread==0（タッチ/クロス）を観測 → 記録
+      - その直後（既定1秒以内）に spread >= 1tick に再拡大した“一拍だけ”片面を最小ロットで提示（GTC+TTL）
+      - 約定したら即IOCで+1tick利確して退出
+      - ガード（health_ok 等）が悪いときは何もしない
+    """
+
+    def __init__(self, *, cfg: Optional[ZeroReopenConfig] = None) -> None:
+        # 何をする関数か：設定と内部状態（直近ゼロ時刻／直近アクション時刻）の初期化
+        super().__init__()
+        self.cfg = cfg or ZeroReopenConfig()
+        self._last_spread_zero_ms: int = -10**9
+        self._last_action_ms: int = -10**9
+
+    # -------------------------
+    # 内部ヘルパ（責務を明記）
+    # -------------------------
+
+    def _mark_zero(self, ob: OrderbookView, now: int) -> None:
+        """【関数】ゼロ記録：spread==0 を見た“時刻”を記録して、のちほど“直後”判定に使う"""
+        if ob.spread_ticks() == 0:
+            self._last_spread_zero_ms = now
+
+    def _is_reopen(self, ob: OrderbookView, now: int) -> bool:
+        """【関数】再拡大判定：“直近ゼロあり かつ 現在は≥min_spread_tick”かどうか"""
+        seen_zero_recently = (now - self._last_spread_zero_ms) <= self.cfg.seen_zero_window_ms
+        return seen_zero_recently and (ob.spread_ticks() >= self.cfg.min_spread_tick)
+
+    def _pass_gates(self, ob: OrderbookView, now: int) -> bool:
+        """【関数】安全ゲート：標準ガード（health_ok）・クールダウン・best存在チェックをまとめて判定"""
+        if not ob.health_ok():
+            return False
+        if (now - self._last_action_ms) < self.cfg.cooloff_ms:
+            return False
+        if ob.best_bid() is None or ob.best_ask() is None:
+            return False
+        return True
+
+    def _choose_side(self, ob: OrderbookView) -> str:
+        """【関数】サイド決定：ミッドからのズレが大きい側（再拡大の外側）で“逆向きに1tick待つ”"""
+        mid = ob.mid_price()
+        bid = ob.best_bid()
+        ask = ob.best_ask()
+        # ask−mid が大きい＝上に開いた ⇒ 戻りBUYを mid−1tick に置く
+        if (ask - mid) >= (mid - bid):
+            return "BUY"
+        # それ以外＝下に開いた ⇒ 戻りSELLを mid＋1tick に置く
+        return "SELL"
+
+    def _build_entry(self, ob: OrderbookView, side: str) -> Order:
+        """【関数】エントリー生成：片面1発の指値（GTC+TTL・最小ロット・戦略タグ付）を作る"""
+        tick = ob.tick_size()
+        mid = ob.mid_price()
+        px = mid - tick if side == "BUY" else mid + tick
+        return Order.limit(
+            side=side,
+            price=px,
+            size=self.cfg.size_min,
+            tif=TIF.GTC,
+            ttl_ms=self.cfg.ttl_ms,
+            tag="zero_reopen",
+        )
+
+    def _build_take_profit(self, ob: OrderbookView, fill) -> Order:
+        """【関数】利確生成：fillを受けたら反対側に+1tickのIOCを即時に返す（秒速撤退）"""
+        tick = ob.tick_size()
+        if fill.side == "BUY":
+            return Order.limit(
+                side="SELL",
+                price=fill.price + tick,
+                size=fill.size,
+                tif=TIF.IOC,
+                ttl_ms=200,
+                tag="zero_reopen_take",
+            )
+        return Order.limit(
+            side="BUY",
+            price=fill.price - tick,
+            size=fill.size,
+            tif=TIF.IOC,
+            ttl_ms=200,
+            tag="zero_reopen_take",
+        )
+
+    # -------------------------
+    # ランタイム・フック
+    # -------------------------
+
+    def on_board(self, ob: OrderbookView) -> List[Order]:
+        """【関数】板イベント：ゼロを記録 → “直後の再拡大 & ゲート合格”なら片面1発だけ返す"""
+        now = now_ms()
+        self._mark_zero(ob, now)
+        if self._is_reopen(ob, now) and self._pass_gates(ob, now):
+            side = self._choose_side(ob)
+            order = self._build_entry(ob, side)
+            self._last_action_ms = now
+            return [order]
+        # ふだんは何もしない（Idle）
+        return []
+
+    def on_fill(self, ob: OrderbookView, my_fill) -> List[Order]:
+        """【関数】約定イベント：+1tickのIOC利確を即返して“秒速で退出”する"""
+        return [self._build_take_profit(ob, my_fill)]


### PR DESCRIPTION
## Summary
- add the Zero→Reopen Pop class to the strategy package registry with exports for discovery
- allow CLI, paper/live engines, and backtest runner to instantiate the new strategy
- define configurable defaults for the Zero→Reopen Pop strategy in the shared base configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d845dd70108329827dd1944991856e