### PR TITLE
Centralize strategy construction across entry points

### DIFF
--- a/src/runtime/engine.py
+++ b/src/runtime/engine.py
@@ -18,10 +18,7 @@ from src.core.orderbook import OrderBook  # 【関数】ローカル板（Best/S
 from src.core.simulator import MiniSimulator  # 【関数】最小約定シミュ（価格タッチ）:contentReference[oaicite:4]{index=4}
 from src.core.logs import OrderLog, TradeLog  # 【関数】発注/約定ログ（Parquet）:contentReference[oaicite:5]{index=5}
 from src.core.analytics import DecisionLog  # 【関数】意思決定ログ（Parquet）:contentReference[oaicite:6]{index=6}
-from src.strategy.stall_then_strike import StallThenStrike  # #1 静止→一撃（ON）:contentReference[oaicite:7]{index=7}
-from src.strategy.cancel_add_gate import CancelAddGate  # #2 キャンセル比ゲート（ON）:contentReference[oaicite:8]{index=8}
-from src.strategy.age_microprice import AgeMicroprice  # #3 エイジ×MP
-from src.strategy.zero_reopen_pop import ZeroReopenPop, zero_reopen_config_from  # ゼロ→再拡大“一拍”だけ片面+即IOC利確
+from src.strategy import build_strategy  # 何をするか：戦略生成を中央ファクトリに委譲する
 
 def _parse_iso(ts: str) -> datetime:
     """【関数】ISO→datetime（'Z'も+00:00に正規化）"""
@@ -50,15 +47,7 @@ class PaperEngine:
 
 
         # 戦略（#1/#2/#3）を選択
-        if strategy_name == "cancel_add_gate":
-            self.strat = CancelAddGate()
-        elif strategy_name == "age_microprice":
-            self.strat = AgeMicroprice()
-        elif strategy_name == "zero_reopen_pop":
-            zr_cfg = strategy_cfg or zero_reopen_config_from(cfg)
-            self.strat = ZeroReopenPop(cfg=zr_cfg)
-        else:
-            self.strat = StallThenStrike()
+        self.strat = build_strategy(strategy_name, cfg, strategy_cfg=strategy_cfg)
 
 
         # ローカル板・シミュ・ログ器

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -2,11 +2,21 @@
 - 役割: 戦略プラグイン（#1〜#7）を入れる箱
 """
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict
+from typing import Any
+
 # 何をするimportか：エントリーポイント（CLI/ランタイム）から戦略クラスを取り出せるようにする
 from .stall_then_strike import StallThenStrike  # 何をするか：#1 静止→一撃（Best静止後にミッド±1tick両面を置く）
 from .cancel_add_gate import CancelAddGate    # 何をするか：#2 キャンセル比ゲート（落ち着いた瞬間だけ片面提示）
 from .age_microprice import AgeMicroprice     # 何をするか：#3 エイジ×マイクロプライス（Age×MPで片面提示）
-from .zero_reopen_pop import ZeroReopenPop    # 何をするか：ゼロ→再拡大の“一拍”だけ狙うワンショットMMのクラスを読み込む
+from .zero_reopen_pop import (
+    ZeroReopenConfig,
+    ZeroReopenPop,
+    zero_reopen_config_from,
+)  # 何をするか：ゼロ→再拡大の“一拍”だけ狙うワンショットMMのクラスと設定を読み込む
 
 # 何をする定義か：戦略名→クラスの対応表（CLI --strategy などから参照）
 STRATEGY_REGISTRY = {
@@ -16,10 +26,67 @@ STRATEGY_REGISTRY = {
     "zero_reopen_pop": ZeroReopenPop,     # 何をするか：spread==0直後の再拡大に片面1tick→当たったら即+1tick利確の戦略を登録
 }
 
+
+def _merge_zero_reopen_cfg(
+    base: ZeroReopenConfig | None, override: Any,
+) -> ZeroReopenConfig | None:
+    """何をする関数か：zero_reopen_pop の設定を base + override でマージする"""
+
+    if override is None:
+        return base
+
+    base_dict = asdict(base) if isinstance(base, ZeroReopenConfig) else {}
+
+    if isinstance(override, ZeroReopenConfig):
+        merged = {**base_dict, **asdict(override)}
+        return ZeroReopenConfig(**merged)
+
+    if isinstance(override, Mapping):
+        merged = {**base_dict, **dict(override)}
+        return ZeroReopenConfig(**merged)
+
+    raise TypeError("zero_reopen_pop override must be ZeroReopenConfig or mapping")
+
+
+def build_strategy(name: str, cfg, *, strategy_cfg: Any = None):
+    """何をする関数か：戦略名からインスタンスを生成する中央ファクトリ"""
+
+    try:
+        cls = STRATEGY_REGISTRY[name]
+    except KeyError as exc:  # 何をするか：未知の戦略名なら明示的に止める
+        raise ValueError(f"unknown strategy: {name}") from exc
+
+    if name == "zero_reopen_pop":
+        merged_cfg = _merge_zero_reopen_cfg(
+            zero_reopen_config_from(cfg), strategy_cfg,
+        )
+        candidates = [
+            ((), {"cfg": merged_cfg}),
+            ((merged_cfg,), {}),
+            ((), {}),
+        ]
+    else:
+        candidates = []
+        if strategy_cfg is not None:
+            candidates.extend([((strategy_cfg,), {}), ((), {"cfg": strategy_cfg})])
+        candidates.extend([((cfg,), {}), ((), {"cfg": cfg}), ((), {})])
+
+    for args, kwargs in candidates:
+        try:
+            return cls(*args, **kwargs)
+        except TypeError:
+            continue
+
+    raise TypeError(f"failed to construct strategy '{name}'")
+
+
 __all__ = [
     "StallThenStrike",
     "CancelAddGate",
     "AgeMicroprice",
     "ZeroReopenPop",
+    "ZeroReopenConfig",
+    "zero_reopen_config_from",
     "STRATEGY_REGISTRY",
+    "build_strategy",
 ]


### PR DESCRIPTION
## Summary
- add a `build_strategy` helper that merges `zero_reopen_pop` configuration overrides before instantiation
- update the live runtime selector, paper engine, backtest runner, and CLI to use the shared factory
- keep optional `strategy_cfg` overrides flowing through the entry points for future customization

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9888279288329aa7eba617ee1e74f