### PR TITLE
Add mid speed gate to zero reopen strategy

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -41,6 +41,7 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
   tiny_prints_minCount: 14 # Tiny-Prints発火閾値（OFFの初期値）
   eta_t_window_ms: 800     # Queue ETAの窓（OFFの初期値）
   zero_reopen_pop:  # 何をする設定か：ゼロ→再拡大の“一拍だけ”出す戦略のパラメータ
+    max_speed_ticks_per_s: 12.0     # 何をする設定か：midの速さ（tick/秒）がこの上限を超えたら発注しない
     min_spread_tick: 1         # 何をする設定か：再拡大の下限tick（1以上で発注可）
     max_spread_tick: 2         # 何をする設定か：再拡大が広すぎるときは出さない上限tick
     ttl_ms: 800                # 何をする設定か：指値の寿命ms（置きっぱなし防止）


### PR DESCRIPTION
## Summary
- add a max_speed_ticks_per_s setting to ZeroReopenConfig
- track the previous mid price and timestamp within ZeroReopenPop
- gate order placement when the mid price speed exceeds the configured threshold
- expose the max_speed_ticks_per_s knob in the base configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daad617bf883299ed7433e53a5c6d7