### PR TITLE
Add decision logging to zero reopen strategy

### DIFF
--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -100,6 +100,14 @@ class ZeroReopenPop(StrategyBase):
     # 内部ヘルパ（責務を明記）
     # -------------------------
 
+    def _log_decision(self, reason: str, **fields) -> None:
+        """【関数】意思決定ログ：何をするか：判断理由と主要パラメータを1行で記録する"""
+        try:
+            payload = " ".join(f"{k}={v}" for k, v in fields.items())
+            logger.info("zr_decision reason=%s %s", reason, payload)
+        except Exception:
+            logger.exception("zr_decision_log_error")
+
     def _get_best_prices(self, ob: OrderBook) -> tuple[float | None, float | None]:
         """【関数】best bid/ask を callable/属性/価格オブジェクトから float に正規化して返す"""
 
@@ -171,6 +179,7 @@ class ZeroReopenPop(StrategyBase):
             if dt_ms > 0:
                 speed_ticks_per_s = abs(mid - self._last_mid_px) / tick * (1000.0 / dt_ms)
                 if speed_ticks_per_s > self.cfg.max_speed_ticks_per_s:
+                    self._log_decision("skip_speed", speed=f"{speed_ticks_per_s:.2f}", limit=self.cfg.max_speed_ticks_per_s)  # 何をするか：速すぎて見送りの理由を記録
                     return False  # 速すぎる＝トレンド急進中と判断し、今回は出さない
         # 記録を更新（次回の速度計算のため）
         self._last_mid_px = mid
@@ -178,6 +187,7 @@ class ZeroReopenPop(StrategyBase):
         # 何をするか：1tick利確の“期待エッジ（bps）”を計算し、手数料合計＋余裕未満なら危険なので発注しない
         edge_est_bp = (tick / max(mid, 1e-9)) * 10000.0 - (self.cfg.fee_maker_bp + self.cfg.fee_taker_bp)
         if edge_est_bp < self.cfg.edge_bp_min:
+            self._log_decision("skip_edge", edge_bp=f"{edge_est_bp:.2f}", min_bp=self.cfg.edge_bp_min)  # 何をするか：採算不足で見送りの理由を記録
             return False
         return True
 
@@ -284,6 +294,7 @@ class ZeroReopenPop(StrategyBase):
                     and self._open_side in {"BUY", "SELL"}
                     and self._open_size > 0.0
                 ):
+                    self._log_decision("flat_timeout", side=self._open_side, size=self._open_size)  # 何をするか：締切超過で非常口フラットを記録
                     order_side = "sell" if self._open_side == "BUY" else "buy"
                     order_price = float(bid_px) if order_side == "sell" else float(ask_px)
                     order = Order(
@@ -308,6 +319,9 @@ class ZeroReopenPop(StrategyBase):
                 action = self._build_entry(ob, side)
             except ValueError:
                 return actions
+            order = action.get("order")
+            order_px = getattr(order, "price", None) if order is not None else None
+            self._log_decision("entry", spread=ob.spread_ticks(), side=side, px=order_px, ttl=self.cfg.ttl_ms)  # 何をするか：エントリー実行を記録
             actions.append(action)
             self._last_action_ms = now_ms
             self._lock_until_ms = now_ms + self.cfg.ttl_ms


### PR DESCRIPTION
## Summary
- add a helper to record zero reopen decision logs in a single line
- log skip conditions, entries, and forced flat events for easier diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc41025a9c83298e0d738847be337a