### PR TITLE
Implement close-only risk gate and entry rate limiting

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -13,6 +13,7 @@ size:  # 取引サイズの下限と既定値
 
 risk:  # リスク上限と非常停止（Kill-Switch）
   max_inventory: 0.2  # 在庫の絶対上限（BTC）
+  inventory_eps: 0.002  # 上限の手前に置く安全マージン（単位=ベース通貨）。この分だけ手前で新規をブロックする
   kill:
     daily_pnl_jpy: -30000  # 日次損益がこの値を下回ったら停止
     max_dd_jpy: -20000     # ドローダウンがこの値を下回ったら停止
@@ -41,6 +42,7 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
   tiny_prints_minCount: 14 # Tiny-Prints発火閾値（OFFの初期値）
   eta_t_window_ms: 800     # Queue ETAの窓（OFFの初期値）
   zero_reopen_pop:  # 何をする設定か：ゼロ→再拡大の“一拍だけ”出す戦略のパラメータ
+    ttl_jitter_ms: 80          # 何をする設定か：TTLに与える±ゆらぎ幅(ms)。同時剥がれの衝突を避ける
     min_best_age_ms: 200        # 何をする設定か：Bestがこの時間（ms）以上変わらず“落ち着いて”いたら発注を許可
     reopen_stable_ms: 50        # 何をする設定か：再拡大がこの時間（ms）続いたら発注を許可（瞬間ノイズはスルー）
     loss_cooloff_ms: 1500      # 何をする設定か：非常口フラット後に“お休み”する時間ms（連続被弾を防ぐ）
@@ -51,6 +53,9 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
     min_spread_tick: 1         # 何をする設定か：再拡大の下限tick（1以上で発注可）
     max_spread_tick: 2         # 何をする設定か：再拡大が広すぎるときは出さない上限tick
     ttl_ms: 800                # 何をする設定か：指値の寿命ms（置きっぱなし防止）
+    stop_adverse_ticks: 2       # 何をする設定か：エントリーVWAPから不利にこのtick以上動いたら即フラットIOCで逃げる
+    entries_window_ms: 10000    # 何をする設定か：この時間窓(ms)内のエントリー回数を数える
+    max_entries_in_window: 6    # 何をする設定か：時間窓内に許可する最大エントリー回数
     size_min: 0.001            # 何をする設定か：最小ロット（取引所の最小単位に合わせる）
     cooloff_ms: 250            # 何をする設定か：連打を防ぐ冷却時間ms
     seen_zero_window_ms: 1000  # 何をする設定か：ゼロを“直後”とみなす時間窓ms

--- a/src/core/risk.py
+++ b/src/core/risk.py
@@ -1,0 +1,88 @@
+"""リスクゲート：在庫上限と安全マージンを扱う補助クラス"""
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+
+def _to_mapping(obj: Any) -> Mapping[str, Any]:
+    """【関数】属性/辞書を読み取り専用の辞書風に正規化"""
+    if obj is None:
+        return {}
+    if isinstance(obj, Mapping):
+        return obj
+    if hasattr(obj, "__dict__") and isinstance(obj.__dict__, MutableMapping):
+        return obj.__dict__
+    return {}
+
+
+class RiskGate:
+    """在庫ゲート（max_inventory と安全マージン inventory_eps を扱う）"""
+
+    def __init__(self, cfg: Any | None = None) -> None:
+        risk_section: Mapping[str, Any] = {}
+        cfg_map = _to_mapping(cfg)
+        if cfg_map:
+            risk_section = _to_mapping(cfg_map.get("risk")) or cfg_map
+        risk_section = risk_section or {}
+
+        max_inv_raw = risk_section.get("max_inventory") if isinstance(risk_section, Mapping) else None
+        self.max_inventory = float(max_inv_raw) if max_inv_raw is not None else None
+
+        default_eps = 0.0
+        if self.max_inventory is not None:
+            default_eps = max(0.0, float(self.max_inventory) * 0.01)
+        eps_raw = risk_section.get("inventory_eps") if isinstance(risk_section, Mapping) else None
+        self.inventory_eps = float(eps_raw) if eps_raw is not None else default_eps
+
+    def effective_inventory_limit(self) -> float | None:
+        """【関数】新規発注の実効上限（max_inventory − inventory_eps）を返す"""
+        if self.max_inventory is None:
+            return None
+        limit = float(self.max_inventory) - float(self.inventory_eps)
+        return max(0.0, limit)
+
+    def would_reduce_inventory(self, current_inventory: float, side: str | None, request_qty: float) -> bool:
+        """【関数】注文が在庫|Q|を減らす（=決済）かどうかを判定"""
+        if side is None:
+            return False
+        try:
+            side_norm = str(side).strip().lower()
+        except Exception:
+            return False
+        if side_norm not in {"buy", "sell"}:
+            return False
+        try:
+            qty = float(request_qty)
+        except (TypeError, ValueError):
+            return False
+        if qty <= 0.0:
+            return False
+        delta = qty if side_norm == "buy" else -qty
+        return abs(current_inventory + delta) <= abs(current_inventory)
+
+    def can_place(
+        self,
+        current_inventory: float,
+        request_qty: float,
+        side: str | None = None,
+        reduce_only: bool = False,
+        **kwargs,
+    ) -> bool:
+        """【関数】在庫ゲート：新規発注を許可するかを判定"""
+        try:
+            qty = abs(float(request_qty))
+        except (TypeError, ValueError):
+            return False
+
+        eff_limit = self.effective_inventory_limit()
+        if eff_limit is None:
+            return True
+
+        if abs(current_inventory) + qty <= eff_limit:
+            return True
+
+        if reduce_only or (side and self.would_reduce_inventory(current_inventory, side, float(request_qty))):
+            return True
+
+        return False

--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Deque, Dict, List, Mapping, Optional
 
 # 何をするimportか：戦略の骨組み・板の読み取り・注文生成・時刻取得（すべて既存の共通層を利用）
 from src.strategy.base import StrategyBase
@@ -13,6 +13,8 @@ from src.core.orders import Order        # Limit/IOC と TTL/タグを付けて�
 from src.core.utils import now_ms        # クールダウンや“直後”判定に使うミリ秒時刻
 
 import logging  # 何をするか：この戦略の意思決定ログを出すために使う
+import random  # 何をするか：TTLに±ゆらぎ（jitter）を与えるための乱数を使う
+from collections import deque  # 何をするか：レート制限用に“時刻のキュー”を使う
 
 
 logger = logging.getLogger(__name__)  # 何をするか：戦略専用のロガーを用意（情報/デバッグを出す）
@@ -34,6 +36,10 @@ class ZeroReopenConfig:
     cooloff_ms: int = 250          # 連打禁止と毒性回避のための“息継ぎ”
     seen_zero_window_ms: int = 1000  # どれだけ“ゼロ直後”を有効とみなすか
     loss_cooloff_ms: int = 1500   # 何をする設定か：非常口フラット後に“お休み”する時間ms（連打で再被弾を防ぐ）
+    stop_adverse_ticks: int = 2    # 何をする設定か：エントリーVWAPから不利にこのtick以上動いたら即フラットIOCで逃げる
+    entries_window_ms: int = 10000   # 何をする設定か：この時間窓（ms）内のエントリー回数を数える
+    max_entries_in_window: int = 6   # 何をする設定か：時間窓内に許可する最大エントリー回数
+    ttl_jitter_ms: int = 80      # 何をする設定か：TTLに与える±ゆらぎ幅（ms）。同時発注の衝突を避ける
     reopen_stable_ms: int = 50   # 何をする設定か：再拡大してから“この時間だけ継続”したら発注を許可（瞬間ノイズで出さない）
     min_best_age_ms: int = 200   # 何をする設定か：Bestがこの時間（ms）以上変わらず“落ち着いて”いたら発注を許
 
@@ -86,6 +92,8 @@ class ZeroReopenPop(StrategyBase):
         self.cfg = cfg or ZeroReopenConfig()
         self._last_spread_zero_ms: int = -10**9
         self._last_action_ms: int = -10**9
+        self._last_entry_ttl_ms: int = self.cfg.ttl_ms  # 何をするか：直近エントリーの実TTL（jitter反映）を記録し、ロック時間と合わせる
+        self._entry_ts_ms: Deque[int] = deque()  # 何をするか：最近のエントリー時刻を入れておく（レート制限判定に使用）
         self._fired_on_this_zero: bool = False  # 何をするか：同一“ゼロ”イベントにつき発注は1回だけにするフラグ
         self._lock_until_ms: int = -10**9  # 何をするか：同時に複数枚を出さない“発注ロック”の期限ms（TTL中は新規禁止）
         self._penalty_until_ms: int = -10**9  # 何をするか：罰ゲーム中はここまで新規発注を禁止（ロス・クールオフの期限ms）
@@ -98,6 +106,7 @@ class ZeroReopenPop(StrategyBase):
         self._tp_pending: bool = False        # 何をするか：利確IOC待ち（まだ手仕舞えていない）かどうか
         self._tp_deadline_ms: int = -10**9    # 何をするか：この時刻を過ぎたら“フラットIOC”を出す締切
         self._open_side: Optional[str] = None # 何をするか：保有している方向（BUY/SELL）
+        self._open_vwap_px: float = 0.0  # 何をするか：保有ポジションの平均価格（VWAP）を記録（部分約定に対応）
         self._open_size: float = 0.0          # 何をするか：保有しているサイズ
         self._last_mid_px: float = 0.0       # 何をするか：前回のmid価格を記録して速さ（速度）を測る
         self._last_mid_ts_ms: int = -10**9   # 何をするか：前回midの記録時刻（ms）
@@ -232,6 +241,17 @@ class ZeroReopenPop(StrategyBase):
         if edge_est_bp < self.cfg.edge_bp_min:
             self._log_decision("skip_edge", edge_bp=f"{edge_est_bp:.2f}", min_bp=self.cfg.edge_bp_min)  # 何をするか：採算不足で見送りの理由を記録
             return False
+
+        if self.cfg.entries_window_ms > 0 and self.cfg.max_entries_in_window > 0:
+            while self._entry_ts_ms and (now_ms - self._entry_ts_ms[0]) > self.cfg.entries_window_ms:
+                self._entry_ts_ms.popleft()  # 何をするか：窓からはみ出た古い記録を捨てる
+            if len(self._entry_ts_ms) >= self.cfg.max_entries_in_window:
+                self._log_decision(
+                    "skip_rate",
+                    n=len(self._entry_ts_ms),
+                    max=self.cfg.max_entries_in_window,
+                )  # 何をするか：レート制限により見送りを記録
+                return False
         return True
 
     def _choose_side(self, ob: OrderBook) -> str:
@@ -291,12 +311,14 @@ class ZeroReopenPop(StrategyBase):
         best_ask = ask_px  # 何をするか：SELL時のメイク価格（tick整合済みのbest）
         side_str = str(side).upper()
         px = best_bid if side_str == "BUY" else best_ask  # 何をするか：BUY→best_bid / SELL→best_ask に統一（ズレ防止）
+        ttl = max(0, int(self.cfg.ttl_ms + random.randint(-self.cfg.ttl_jitter_ms, self.cfg.ttl_jitter_ms)))  # 何をするか：TTLに±ゆらぎを与える
+        self._last_entry_ttl_ms = ttl  # 何をするか：この発注に使う実TTLを記録（のちのロック解除に使う）
         order = Order(
             side=side,
             price=px,
             size=self.cfg.size_min,
             tif="GTC",
-            ttl_ms=self.cfg.ttl_ms,
+            ttl_ms=self._last_entry_ttl_ms,
             tag=self._entry_tag,
         )
         return {"type": "place", "order": order}
@@ -379,6 +401,47 @@ class ZeroReopenPop(StrategyBase):
                     return actions
             return actions
 
+        # 何をするか：逆行が規定tickを超えたら、時間を待たずに即フラットIOCで逃げる
+        if self._tp_pending and self._open_size > 0.0 and self.cfg.stop_adverse_ticks > 0:
+            best_bid, best_ask = self._get_best_prices(ob)
+            if best_bid is not None and best_ask is not None and self._open_vwap_px > 0.0:
+                try:
+                    tick = float(ob.tick_size())
+                except Exception:
+                    tick = 0.0
+                tick = max(tick, 1e-12)
+                adverse_ticks = 0.0
+                if self._open_side == "BUY":
+                    adverse_ticks = max(0.0, (self._open_vwap_px - float(best_bid)) / tick)
+                elif self._open_side == "SELL":
+                    adverse_ticks = max(0.0, (float(best_ask) - self._open_vwap_px) / tick)
+                if adverse_ticks >= self.cfg.stop_adverse_ticks:
+                    self._log_decision(
+                        "flat_adverse",
+                        side=self._open_side,
+                        adv_ticks=f"{adverse_ticks:.1f}",
+                        stop=self.cfg.stop_adverse_ticks,
+                    )
+                    if self._open_side == "BUY":
+                        order = Order(
+                            side="sell",
+                            price=float(best_bid),
+                            size=self._open_size,
+                            tif="IOC",
+                            ttl_ms=200,
+                            tag="zero_reopen_flat",
+                        )
+                    else:
+                        order = Order(
+                            side="buy",
+                            price=float(best_ask),
+                            size=self._open_size,
+                            tif="IOC",
+                            ttl_ms=200,
+                            tag="zero_reopen_flat",
+                        )
+                    return [{"type": "place", "order": order}]
+
         if self._entry_active and (now_ms >= self._lock_until_ms or not self._is_reopen(ob, now_ms)):
             actions.append(self._build_cancel())
 
@@ -393,7 +456,8 @@ class ZeroReopenPop(StrategyBase):
             self._log_decision("entry", spread=ob.spread_ticks(), side=side, px=order_px, ttl=self.cfg.ttl_ms)  # 何をするか：エントリー実行を記録
             actions.append(action)
             self._last_action_ms = now_ms
-            self._lock_until_ms = now_ms + self.cfg.ttl_ms
+            self._lock_until_ms = now_ms + self._last_entry_ttl_ms  # 何をするか：ロックは“実際に使ったTTL分だけ”かける
+            self._entry_ts_ms.append(now_ms)  # 何をするか：このエントリーの時刻を記録（レート制限判定で使用）
             self._entry_active = True
             self._fired_on_this_zero = True  # 何をするか：この“ゼロ”での発注を消費（次は新しいゼロが来るまで出さない）
 
@@ -428,6 +492,7 @@ class ZeroReopenPop(StrategyBase):
                 self._open_size = 0.0
                 self._tp_pending = False
                 self._open_side = None
+                self._open_vwap_px = 0.0  # 何をするか：在庫がゼロになったのでVWAPをリセット
                 self._lock_until_ms = now - 1
             else:
                 self._tp_pending = True
@@ -449,29 +514,48 @@ class ZeroReopenPop(StrategyBase):
         # 何をするか：エントリー約定を受けたので、利確IOCの“締切”をセットして待機フラグON
         fill_side = getattr(my_fill, "side", None)
         fill_size = getattr(my_fill, "size", None)
+        fill_price = getattr(my_fill, "price", None)
         if isinstance(my_fill, Mapping):
             if fill_side is None:
                 fill_side = my_fill.get("side")
             if fill_size is None:
                 fill_size = my_fill.get("size")
+            if fill_price is None:
+                fill_price = my_fill.get("price")
             order_info = my_fill.get("order")
-            if fill_side is None and order_info is not None:
-                fill_side = getattr(order_info, "side", None)
-            if fill_size is None and order_info is not None:
-                fill_size = getattr(order_info, "size", None)
+            if order_info is not None:
+                if fill_side is None:
+                    fill_side = getattr(order_info, "side", None)
+                if fill_size is None:
+                    fill_size = getattr(order_info, "size", None)
+                if fill_price is None:
+                    fill_price = getattr(order_info, "price", None)
         side_str = str(fill_side).upper() if fill_side is not None else None
         size_val = float(fill_size) if fill_size is not None else 0.0
         if size_val <= 0.0:
             size_val = 0.0
+        price_val = float(fill_price) if fill_price is not None else None
         self._tp_pending = True
         self._tp_deadline_ms = now + self.cfg.flat_timeout_ms
-        if self._open_side is None and side_str:
-            self._open_side = side_str
-        self._open_size += size_val
+        if self._open_side is None:
+            if side_str:
+                self._open_side = side_str
+            self._open_size = size_val
+            self._open_vwap_px = price_val if price_val is not None else 0.0
+        else:
+            if size_val > 0.0:
+                new_size = self._open_size + size_val
+                if price_val is not None:
+                    self._open_vwap_px = (
+                        (self._open_vwap_px * self._open_size + price_val * size_val)
+                        / max(new_size, 1e-12)
+                    )
+                self._open_size = new_size
         if self._open_size <= 1e-12:
             self._tp_pending = False
             self._open_side = None
             self._open_size = 0.0
+            self._open_vwap_px = 0.0
 
         try:
             action = self._build_take_profit(ob, my_fill)


### PR DESCRIPTION
## Summary
- add a reusable RiskGate helper that reads inventory safety margin, computes an effective limit, and permits close-only orders when near the cap
- extend zero_reopen_pop with entry rate limiting, jitter-aware TTL bookkeeping, and new configuration knobs for the time window and maximum entries
- expose the rate limiting parameters in the base configuration so strategies can tune the entry burst control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf0d067b083298dde3cd05f0321cc