### PR TITLE
Add exact_one_tick_only option to base config

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -42,6 +42,7 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
   tiny_prints_minCount: 14 # Tiny-Prints発火閾値（OFFの初期値）
   eta_t_window_ms: 800     # Queue ETAの窓（OFFの初期値）
   zero_reopen_pop:  # 何をする設定か：ゼロ→再拡大の“一拍だけ”出す戦略のパラメータ
+    exact_one_tick_only: true    # 何をする設定か：スプレッドが“1tickちょうど”の時だけ出す（+1tick利確が即時一致）
     ttl_jitter_ms: 80          # 何をする設定か：TTLに与える±ゆらぎ幅(ms)。同時剥がれの衝突を避ける
     min_best_age_ms: 200        # 何をする設定か：Bestがこの時間（ms）以上変わらず“落ち着いて”いたら発注を許可
     reopen_stable_ms: 50        # 何をする設定か：再拡大がこの時間（ms）続いたら発注を許可（瞬間ノイズはスルー）


### PR DESCRIPTION
## Summary
- enable the exact_one_tick_only toggle in the base configuration to ensure +1 tick take-profit IOC orders only fire when the spread is exactly one tick

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded0c864808329b60fc050dfde744c