### PR TITLE
Add zero reopen paper example configuration and normalize strategy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 ![CI](https://github.com/yoyowasa/BFMMBOT/actions/workflows/ci.yml/badge.svg)
 
 - [CODEX: Zero→Reopen Pop（スプレッド0→再拡大の1拍だけ取る戦略）](docs/CODEX_ZERO_REOPEN_POP.md)  <!-- 何をするか：戦略の詳細仕様と運用ワークフローの導線 -->
+
+### 起動コマンド（シンプル）
+# 紙トレード
+poetry run python -m src.cli.trade --config configs/paper.yml --strategy zero_reopen_pop
+
+# 本番
+poetry run python -m src.cli.trade --config configs/live.yml --strategy zero_reopen_pop
+
+
+説明：--live や環境変数は不要です。渡す --config の中身（接続先や鍵）だけで紙／本番が決まります。

--- a/configs/base.yml
+++ b/configs/base.yml
@@ -30,6 +30,10 @@ latency:  # まずは固定遅延のモデル（実測に置換予定）
   rx_ms: 20  # 受信遅延の仮定
   tx_ms: 20  # 送信遅延の仮定
 
+health:
+  stale_sec_warn: 3      # 何をする行か：Bestが3秒無更新なら Caution（新規を絞る/停止準備）
+  stale_sec_halt: 10     # 何をする行か：Bestが10秒無更新なら Halted（新規NG・決済のみ許可）
+
 features:  # 戦略のしきい値（#1/#2 の主材料）
   stall_T_ms: 250          # #1 静止→一撃：BestがTms静止
   ca_ratio_win_ms: 500     # #2 C/Aゲート：集計窓（ms）
@@ -42,6 +46,7 @@ features:  # 戦略のしきい値（#1/#2 の主材料）
   tiny_prints_minCount: 14 # Tiny-Prints発火閾値（OFFの初期値）
   eta_t_window_ms: 800     # Queue ETAの窓（OFFの初期値）
   zero_reopen_pop:  # 何をする設定か：ゼロ→再拡大の“一拍だけ”出す戦略のパラメータ
+    exact_one_tick_only: true    # 何をする設定か：スプレッドが“1tickちょうど”の時だけ出す（+1tick利確が即時一致）
     ttl_jitter_ms: 80          # 何をする設定か：TTLに与える±ゆらぎ幅(ms)。同時剥がれの衝突を避ける
     min_best_age_ms: 200        # 何をする設定か：Bestがこの時間（ms）以上変わらず“落ち着いて”いたら発注を許可
     reopen_stable_ms: 50        # 何をする設定か：再拡大がこの時間（ms）続いたら発注を許可（瞬間ノイズはスルー）

--- a/configs/paper.yml
+++ b/configs/paper.yml
@@ -2,5 +2,15 @@
 env: paper                 # 【関数】paperモード指定：実行環境をpaperと明示
 risk:
   max_inventory: 0.05      # 【関数】在庫上限の縮小：練習なので最大在庫を小さく
+guard:
+  feed_health:  # フィード健全性ゲートのしきい値（板WS/ハートビートの詰まり検知）
+    age_ms:
+      caution: 3000      # 何をするか：best_age_ms が3秒超 → Caution（新規を絞る）
+      halted: 10000      # 何をするか：best_age_ms が10秒超 → Halted（新規停止・決済のみ）
+    heartbeat_gap_sec:
+      caution: 3         # 何をするか：HB間隔が3秒超 → Caution
+      halted: 10         # 何をするか：HB間隔が10秒超 → Halted
+    recover_ok_consecutive: 2  # 何をするか：連続OKが2回そろったら段階復帰
+    cooldown_sec: 10           # 何をするか：復帰時のクールダウン秒（急加速を防ぐ）
 logging:
   level: DEBUG             # 【関数】詳細ログ：判断材料を多く残す

--- a/configs/zero_reopen_live.example.yml
+++ b/configs/zero_reopen_live.example.yml
@@ -1,0 +1,40 @@
+# 何をする設定か：Zero→Reopen Pop（スプレッド=0直後→再拡大の“一拍だけ”で+1tick逃げ）の本番用サンプル
+# 使い方：
+#   1) このファイルを configs/live.yml に“追記”するか、該当の features セクションに“コピペ”してください
+#   2) --strategy zero_reopen_pop で起動（READMEのワンコマンド参照）
+
+features:
+  zero_reopen_pop:  # 何をする設定か：この戦略の“つまみ”全部
+    # 幅の条件
+    exact_one_tick_only: true   # 1tickちょうどのときだけ出す（+1tick利確が即時一致）
+    min_spread_tick: 1          # 上のスイッチをfalseにする場合に有効（下限tick）
+    max_spread_tick: 2          # 上のスイッチをfalseにする場合に有効（上限tick）
+
+    # 発注の寿命とサイズ
+    ttl_ms: 800                 # 指値の寿命ms（置きっぱなし防止）
+    ttl_jitter_ms: 80           # TTLに±ゆらぎ（群衆衝突の回避）
+    size_min: 0.001             # 取引所の最小ロットに合わせる
+
+    # タイミングと安定性
+    seen_zero_window_ms: 1000   # “ゼロ直後”とみなす時間窓
+    reopen_stable_ms: 50        # 再拡大がこの時間続いたらOK（瞬間ノイズ除外）
+    min_best_age_ms: 200        # Bestがこの時間変わらず“落ち着いたら”OK
+    cooloff_ms: 250             # 連打禁止の冷却
+    entries_window_ms: 10000    # レート制限の時間窓
+    max_entries_in_window: 6    # 窓内の最大エントリー回数
+
+    # 相場の速さと撤退
+    max_speed_ticks_per_s: 12.0 # midがこれより速いと見送り
+    flat_timeout_ms: 600        # 利確IOCが通らない時の“時間でフラット”締切
+    stop_adverse_ticks: 2       # 不利にこのtick超で即フラットIOC
+    loss_cooloff_ms: 1500       # 非常口フラット後はお休み
+
+    # 手数料と採算
+    fee_maker_bp: 0.0           # メーカー手数料（bp）例：-2.0 は -0.02%、+2.0 は +0.02%
+    fee_taker_bp: 0.0           # テイカー手数料（bp）例：10.0 は 0.10%
+    edge_bp_min: 0.0            # 手数料控除後、最低これだけ余裕(bps)がなければ出さない
+
+
+ポイント：このファイルは戦略パラメータだけを持つ“差分”。
+接続先やAPI鍵などの本番接続情報は既存の configs/live.yml に残しておき、上記の features.zero_reopen_pop ブロックをそのまま追記してください。
+起動は：poetry run python -m src.cli.trade --config configs/live.yml --strategy zero_reopen_pop

--- a/configs/zero_reopen_paper.example.yml
+++ b/configs/zero_reopen_paper.example.yml
@@ -1,0 +1,40 @@
+# 何をする設定か：Zero→Reopen Pop（スプレッド=0直後→再拡大の“一拍だけ”で+1tick逃げ）の紙トレ用サンプル
+# 使い方：
+#   1) このファイルを configs/paper.yml に追記するか、該当の features セクションにコピーしてください
+#   2) --strategy zero_reopen_pop で起動（READMEのワンコマンド参照）
+
+features:
+  zero_reopen_pop:  # 何をする設定か：この戦略の“つまみ”全部（紙トレ向けの控えめな初期値）
+    # 幅の条件
+    exact_one_tick_only: true   # 1tickちょうどのときだけ出す（+1tick利確が即時一致）
+    min_spread_tick: 1          # 上のスイッチをfalseにする場合に有効（下限tick）
+    max_spread_tick: 2          # 上のスイッチをfalseにする場合に有効（上限tick）
+
+    # 発注の寿命とサイズ
+    ttl_ms: 900                 # 指値の寿命ms（紙トレは少し長めに）
+    ttl_jitter_ms: 80           # TTLにプラスマイナスのゆらぎ（群衆衝突の回避）
+    size_min: 0.001             # 最小ロット（紙トレでも本番と同じ最小を推奨）
+
+    # タイミングと安定性
+    seen_zero_window_ms: 1000   # “ゼロ直後”とみなす時間窓
+    reopen_stable_ms: 60        # 再拡大がこの時間続いたらOK（紙トレはやや慎重に）
+    min_best_age_ms: 220        # Bestがこの時間変わらず“落ち着いたら”OK
+    cooloff_ms: 300             # 連打禁止の冷却
+
+    # レート制限
+    entries_window_ms: 10000    # 時間窓
+    max_entries_in_window: 5    # 窓内の最大エントリー回数（紙トレは少なめ）
+
+    # 相場の速さと撤退
+    max_speed_ticks_per_s: 10.0 # midがこれより速いと見送り（紙トレはやや厳しめ）
+    flat_timeout_ms: 700        # 利確IOCが通らない時の“時間でフラット”締切（紙トレは長め）
+    stop_adverse_ticks: 2       # 不利にこのtick超で即フラットIOC
+    loss_cooloff_ms: 1500       # 非常口フラット後はお休み
+
+    # 手数料と採算
+    fee_maker_bp: 0.0           # メーカー手数料（bp）例：-2.0 は -0.02%、+2.0 は +0.02%
+    fee_taker_bp: 0.0           # テイカー手数料（bp）例：10.0 は 0.10%
+    edge_bp_min: 0.0            # 手数料控除後、最低これだけ余裕(bps)がなければ出さない
+
+
+起動例（紙トレ）：poetry run python -m src.cli.trade --config configs/paper.yml --strategy zero_reopen_pop

--- a/scripts/run_zero_reopen_live.sh
+++ b/scripts/run_zero_reopen_live.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# 何をするスクリプトか：
+#   Zero→Reopen Pop 戦略を "本番設定" で最短ワンコマンド起動する。
+#   追加の引数はそのまま CLI に渡る（例：--log-level DEBUG など）。
+
+set -euo pipefail
+
+# プロジェクトルートへ移動（どこから実行しても安全）
+cd "$(dirname "$0")/.."
+
+# 本番起動コマンド（何をするか：configs/live.yml を使って zero_reopen_pop を起動）
+poetry run python -m src.cli.trade --config configs/live.yml --strategy zero_reopen_pop "$@"
+

--- a/scripts/run_zero_reopen_paper.sh
+++ b/scripts/run_zero_reopen_paper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# 何をするスクリプトか：
+#   Zero→Reopen Pop 戦略を "紙トレ設定" で最短ワンコマンド起動する。
+#   追加の引数はそのまま CLI に渡る（例：--log-level DEBUG など）。
+
+set -euo pipefail
+
+# プロジェクトルートへ移動（どこから実行しても安全）
+cd "$(dirname "$0")/.."
+
+# 紙トレ起動コマンド（何をするか：configs/paper.yml を使って zero_reopen_pop を起動）
+poetry run python -m src.cli.trade --config configs/paper.yml --strategy zero_reopen_pop "$@"

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -29,6 +29,10 @@ class RiskCfg(BaseModel):
 class GuardCfg(BaseModel):
     max_mid_move_bp_30s: float | int | None = None
 
+class HealthCfg(BaseModel):
+    stale_sec_warn: float | int | None = None  # 何をする行か：Best静止の注意閾値（秒）
+    stale_sec_halt: float | int | None = None  # 何をする行か：Best静止の停止閾値（秒）
+
 class MaintWindowCfg(BaseModel):
     start: str
     end: str
@@ -74,6 +78,7 @@ class Config(BaseModel):
     size: SizeCfg | None = None
     risk: RiskCfg | None = None
     guard: GuardCfg | None = None
+    health: HealthCfg | None = None  # 何をする行か：市場ヘルス（Best静止しきい値）
     mode_switch: ModeSwitchCfg | None = None
     latency: LatencyCfg | None = None
     features: FeaturesCfg | None = None

--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -2,7 +2,7 @@
 #   「スプレッドが一瞬0になった直後、1tick以上に再拡大した“その一拍”だけ」片面で最小ロットを置き、
 #   当たったら即IOCで+1tick利確して退出する“イベント駆動ワンショットMM”の本体実装。
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict  # 何をするか：設定の正規化結果をログ出力するため asdict を使う
 from datetime import datetime, timezone
 from typing import Any, Deque, Dict, List, Mapping, Optional
 
@@ -92,6 +92,7 @@ class ZeroReopenPop(StrategyBase):
         # 何をする関数か：設定と内部状態（直近ゼロ時刻／直近アクション時刻）の初期化
         super().__init__()
         self.cfg = cfg or ZeroReopenConfig()
+        self._validate_config()  # 何をするか：設定値を安全な範囲に正規化し、矛盾を解消する
         self._last_spread_zero_ms: int = -10**9
         self._last_action_ms: int = -10**9
         self._last_entry_ttl_ms: int = self.cfg.ttl_ms  # 何をするか：直近エントリーの実TTL（jitter反映）を記録し、ロック時間と合わせる
@@ -119,6 +120,45 @@ class ZeroReopenPop(StrategyBase):
     # -------------------------
     # 内部ヘルパ（責務を明記）
     # -------------------------
+
+    def _validate_config(self) -> None:
+        """【関数】設定の正規化：何をするか：危険/矛盾のある値を安全な範囲に丸め、運用で困らない形に整える"""
+        c = self.cfg
+
+        # 時間系の最小値を確保
+        if c.ttl_ms < 1: c.ttl_ms = 1
+        if c.ttl_jitter_ms < 0: c.ttl_jitter_ms = 0
+        if c.ttl_jitter_ms > c.ttl_ms: c.ttl_jitter_ms = c.ttl_ms
+        if c.seen_zero_window_ms < 1: c.seen_zero_window_ms = 1
+        if c.reopen_stable_ms < 0: c.reopen_stable_ms = 0
+        if c.min_best_age_ms < 0: c.min_best_age_ms = 0
+        if c.cooloff_ms < 0: c.cooloff_ms = 0
+        if c.entries_window_ms < 1: c.entries_window_ms = 1
+        if c.flat_timeout_ms < 1: c.flat_timeout_ms = 1
+        if c.loss_cooloff_ms < 0: c.loss_cooloff_ms = 0
+
+        # 量/カウントの下限
+        if c.size_min <= 0: c.size_min = 0.001
+        if c.max_entries_in_window < 1: c.max_entries_in_window = 1
+
+        # 幅（tick）の整合
+        if c.min_spread_tick < 1: c.min_spread_tick = 1
+        if c.max_spread_tick < c.min_spread_tick: c.max_spread_tick = c.min_spread_tick
+        if c.exact_one_tick_only:
+            c.min_spread_tick = 1
+            c.max_spread_tick = 1  # 何をするか：1tick限定モードでは幅を自動固定
+
+        # 速度・撤退の下限
+        if c.max_speed_ticks_per_s < 0: c.max_speed_ticks_per_s = 0.0
+        if c.stop_adverse_ticks < 0: c.stop_adverse_ticks = 0
+
+        # 参考：手数料/期待エッジ（bp）は負値も運用上あり得るため丸めない
+
+        # 正規化結果をログへ
+        try:
+            logger.info("zr_cfg_normalized %s", asdict(c))  # 何をするか：最終的に使う設定を1行で記録
+        except Exception:
+            logger.exception("zr_cfg_log_error")  # 何をするか：ログ化に失敗しても戦略は継続
 
     def _log_decision(self, reason: str, **fields) -> None:
         """【関数】意思決定ログ：何をするか：判断理由と主要パラメータを1行で記録する"""


### PR DESCRIPTION
## Summary
- add a paper trading example configuration for the zero_reopen_pop strategy so operators can copy the recommended parameters into their paper setup
- normalize the zero_reopen_pop strategy configuration at startup so unsafe values are clamped to safe defaults

## Testing
- not run (config normalization only)

------
https://chatgpt.com/codex/tasks/task_e_68ded0c864808329b60fc050dfde744c