### PR TITLE
Add max join quantity gate for zero reopen strategy

### DIFF
--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -34,6 +34,7 @@ class ZeroReopenConfig:
     ttl_ms: int = 800              # 指値の寿命（置きっぱなし防止・秒速撤退のため短め）
     size_min: float = 0.001        # 最小ロット（取引所の最小単位に合わせる）
     min_take_qty: float = 0.0    # 何をする設定か：+1tick利確の相手側Bestに最低この数量が無いと発注しない（0で無効）
+    max_join_qty: float = 0.0   # 何をする設定か：自分が並ぶ側のBest数量がこの値を超えていたら出さない（0で無効）
     cooloff_ms: int = 250          # 連打禁止と毒性回避のための“息継ぎ”
     seen_zero_window_ms: int = 1000  # どれだけ“ゼロ直後”を有効とみなすか
     loss_cooloff_ms: int = 1500   # 何をする設定か：非常口フラット後に“お休み”する時間ms（連打で再被弾を防ぐ）
@@ -495,6 +496,15 @@ class ZeroReopenPop(StrategyBase):
         if self._is_reopen(ob, now_ms) and self._pass_gates(ob, now_ms):
             try:
                 side = self._choose_side(ob)
+                # 何をするか：自分が並ぶ側のBestの“行列（数量）”が多すぎるなら、順番が回りにくいので今回は出さない
+                if self.cfg.max_join_qty > 0:
+                    maker_size_reader = (
+                        getattr(ob, "best_bid_size", None) if side == "BUY" else getattr(ob, "best_ask_size", None)
+                    )
+                    maker_sz = maker_size_reader() if callable(maker_size_reader) else None  # 何をするか：板ビューが数量APIを持っていれば読む（無ければスキップ）
+                    if (maker_sz is not None) and (maker_sz > self.cfg.max_join_qty):
+                        self._log_decision("skip_maker_queue", have=maker_sz, max=self.cfg.max_join_qty, side=side)  # 何をするか：見送り理由を記録
+                        return []
                 # 何をするか：+1tick利確が通りやすいよう、相手側Bestの板厚が足りなければ今回は出さない
                 if self.cfg.min_take_qty > 0:
                     size_reader = getattr(ob, "best_ask_size", None) if side == "BUY" else getattr(ob, "best_bid_size", None)


### PR DESCRIPTION
## Summary
- add a max_join_qty configuration knob to skip entries when the maker queue is too deep
- guard evaluate flow to log and skip when best-side size exceeds max_join_qty

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df59c0b5508329b8f890b46442acba