### PR TITLE
Enable per-strategy text logs in trade CLI

### DIFF
--- a/configs/base.yml
+++ b/configs/base.yml
@@ -74,3 +74,6 @@ strategies:  # まずは2本だけON（他はOFF）
 logging:  # ログ出力の基本設定
   level: INFO     # paper既定はINFO（paper.ymlでDEBUGに上書き予定）
   rotate_mb: 128  # ログローテーションの閾値（MB）
+  run_log_template: logs/runtime/run.log  # 何をする設定か：共通run.logの出力先テンプレート
+  strategy_log_template: null  # 何をする設定か：戦略専用ログのテンプレート（nullで無効）
+  strategy_level: null  # 何をする設定か：戦略専用ログのレベル（nullならlevelを流用）

--- a/src/cli/trade.py
+++ b/src/cli/trade.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse  # 引数処理
 import asyncio  # 非同期ランタイム
+from collections.abc import Mapping  # 何をするか：設定のdictアクセスを許可
 from loguru import logger  # 実行ログ
 try:
     from dotenv import load_dotenv, find_dotenv  # 何をするか：.env を読み込む（healthと同じ方式）
@@ -14,6 +15,68 @@ except Exception:
 
 
 from pathlib import Path  # run.log の保存先を扱う
+
+
+def _cfg_get(obj, key: str, default):
+    """何をする関数か：設定オブジェクトから属性/キーを安全に取得する"""
+    if obj is None:
+        return default
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _format_log_template(template: str | None, strategy: str) -> str | None:
+    """何をする関数か：テンプレート文字列に strategy 名を埋め込み、失敗時は原文を返す"""
+    if not template:
+        return None
+    try:
+        return template.format(strategy=strategy)
+    except KeyError:
+        return template
+    except Exception as exc:
+        logger.warning(f"log_template_format_failed template={template} err={exc}")
+        return template
+
+
+def _setup_text_logs(cfg, strategy: str) -> list[int]:
+    """何をする関数か：共通run.logと戦略別ログのシンクを初期化する"""
+    log_cfg = getattr(cfg, "logging", None)
+    rotate_mb = _cfg_get(log_cfg, "rotate_mb", 128)
+    base_level = _cfg_get(log_cfg, "level", "INFO")
+    run_template = _cfg_get(log_cfg, "run_log_template", None)
+    strategy_template = _cfg_get(log_cfg, "strategy_log_template", None)
+    strategy_level = _cfg_get(log_cfg, "strategy_level", None) or base_level
+
+    sink_ids: list[int] = []
+    seen_paths: set[str] = set()
+
+    def _add_sink(path_str: str | None, level: str) -> None:
+        if not path_str:
+            return
+        path = Path(path_str).expanduser()
+        key = str(path)
+        if key in seen_paths:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            logger.error(f"log_path_mkdir_failed path={path} err={exc}")
+            return
+        rotation = f"{int(rotate_mb)} MB"
+        sink_ids.append(logger.add(path, level=level, rotation=rotation, enqueue=True))
+        seen_paths.add(key)
+
+    resolved_run = _format_log_template(run_template, strategy)
+    if not resolved_run:
+        resolved_run = "logs/runtime/run.log"
+    _add_sink(resolved_run, base_level)
+
+    resolved_strategy = _format_log_template(strategy_template, strategy)
+    if resolved_strategy:
+        _add_sink(resolved_strategy, strategy_level)
+
+    return sink_ids
 
 from src.core.utils import load_config  # 【関数】設定ローダー（base＋上書き）:contentReference[oaicite:12]{index=12}
 from src.runtime.engine import PaperEngine  # 【関数】paperエンジン（本ステップ）
@@ -42,56 +105,53 @@ def main() -> None:
     args = _parse_args()
     cfg = load_config(args.config)
     strategy_cfg = None
-    # 何をするか：設定の env を見て live/paper を切り替える（ワークフローの 8.3→8.4 切替）
-    if getattr(cfg, "env", "paper") == "live":
-        if args.paper:  # 何をするか：--paper 指定なら疑似発注（fillsまで再現）
-            rp = run_paper  # 何をするか：まずは通常のrun_paperを候補にする
-            if rp is None:
-                import importlib  # 何をするか：モジュールを動的に読み込んで関数を探す
-                try:
-                    mod = importlib.import_module("src.runtime.engine")  # 何をするか：engine内の別名候補を探す
-                    for name in ("run_paper", "paper_main", "run_paper_engine", "paper_run"):
-                        fn = getattr(mod, name, None)
-                        if callable(fn):
-                            rp = fn
-                            break
-                except Exception:
-                    rp = None
+    sink_ids = _setup_text_logs(cfg, args.strategy)
+    try:
+        # 何をするか：設定の env を見て live/paper を切り替える（ワークフローの 8.3→8.4 切替）
+        if getattr(cfg, "env", "paper") == "live":
+            if args.paper:  # 何をするか：--paper 指定なら疑似発注（fillsまで再現）
+                rp = run_paper  # 何をするか：まずは通常のrun_paperを候補にする
                 if rp is None:
+                    import importlib  # 何をするか：モジュールを動的に読み込んで関数を探す
                     try:
-                        mod2 = importlib.import_module("src.runtime.paper")  # 何をするか：paper専用モジュールがあれば使う
-                        for name in ("run_paper", "main", "run"):
-                            fn = getattr(mod2, name, None)
+                        mod = importlib.import_module("src.runtime.engine")  # 何をするか：engine内の別名候補を探す
+                        for name in ("run_paper", "paper_main", "run_paper_engine", "paper_run"):
+                            fn = getattr(mod, name, None)
                             if callable(fn):
                                 rp = fn
                                 break
                     except Exception:
                         rp = None
-            if rp is None:
-                raise RuntimeError("paper runner が見つかりません（engine.run_paper / engine.paper_main / runtime.paper.main などを確認）")  # 何をするか：どこにも無ければ分かりやすく停止
-            try:
-                rp(cfg, args.strategy, strategy_cfg=strategy_cfg)  # 何をするか：見つけた入口でペーパー運転を開始
-            except TypeError:
-                rp(cfg, args.strategy)  # 互換：旧シグネチャ（strategy_cfg未対応）の場合は従来呼び出し
-        else:
-            run_live(cfg, args.strategy, dry_run=args.dry_run, strategy_cfg=strategy_cfg)  # 何をするか：従来どおりlive/dry-run
+                    if rp is None:
+                        try:
+                            mod2 = importlib.import_module("src.runtime.paper")  # 何をするか：paper専用モジュールがあれば使う
+                            for name in ("run_paper", "main", "run"):
+                                fn = getattr(mod2, name, None)
+                                if callable(fn):
+                                    rp = fn
+                                    break
+                        except Exception:
+                            rp = None
+                if rp is None:
+                    raise RuntimeError("paper runner が見つかりません（engine.run_paper / engine.paper_main / runtime.paper.main などを確認）")  # 何をするか：どこにも無ければ分かりやすく停止
+                try:
+                    rp(cfg, args.strategy, strategy_cfg=strategy_cfg)  # 何をするか：見つけた入口でペーパー運転を開始
+                except TypeError:
+                    rp(cfg, args.strategy)  # 互換：旧シグネチャ（strategy_cfg未対応）の場合は従来呼び出し
+            else:
+                run_live(cfg, args.strategy, dry_run=args.dry_run, strategy_cfg=strategy_cfg)  # 何をするか：従来どおりlive/dry-run
+            return  # 何をするか：live 分岐ではここで終了（paper へは進まない）
 
-
-        return  # 何をするか：live 分岐ではここで終了（paper へは進まない）
-
-    log_path = Path("logs/runtime/run.log")  # 【関数】ログファイルの出力先
-    log_path.parent.mkdir(parents=True, exist_ok=True)  # フォルダ作成
-    rotate_mb = getattr(getattr(cfg, "logging", None), "rotate_mb", 128)  # 既定128MB
-    level = getattr(getattr(cfg, "logging", None), "level", "INFO")  # 既定INFO
-    logger.add(log_path, level=level, rotation=f"{int(rotate_mb)} MB", enqueue=True)  # ローテ付きで出力
-
-    if cfg.env != "paper":
-        logger.warning(f"env is '{cfg.env}' (expected 'paper') - 続行はします")
-    engine = PaperEngine(cfg, args.strategy, strategy_cfg=strategy_cfg)
-    try:
-        asyncio.run(engine.run_paper())
-    except KeyboardInterrupt:
-        pass
+        if cfg.env != "paper":
+            logger.warning(f"env is '{cfg.env}' (expected 'paper') - 続行はします")
+        engine = PaperEngine(cfg, args.strategy, strategy_cfg=strategy_cfg)
+        try:
+            asyncio.run(engine.run_paper())
+        except KeyboardInterrupt:
+            pass
+    finally:
+        for sink_id in sink_ids:
+            logger.remove(sink_id)
 
 if __name__ == "__main__":
     main()

--- a/src/strategy/zero_reopen_pop.py
+++ b/src/strategy/zero_reopen_pop.py
@@ -12,12 +12,9 @@ from src.core.orderbook import OrderBook  # best/中値/tick/スプレッド/健
 from src.core.orders import Order        # Limit/IOC と TTL/タグを付けて発注する型
 from src.core.utils import now_ms        # クールダウンや“直後”判定に使うミリ秒時刻
 
-import logging  # 何をするか：この戦略の意思決定ログを出すために使う
+from loguru import logger  # 何をするか：この戦略の意思決定ログを出すために使う
 import random  # 何をするか：TTLに±ゆらぎ（jitter）を与えるための乱数を使う
 from collections import deque  # 何をするか：レート制限用に“時刻のキュー”を使う
-
-
-logger = logging.getLogger(__name__)  # 何をするか：戦略専用のロガーを用意（情報/デバッグを出す）
 
 
 @dataclass
@@ -158,7 +155,7 @@ class ZeroReopenPop(StrategyBase):
 
         # 正規化結果をログへ
         try:
-            logger.info("zr_cfg_normalized %s", asdict(c))  # 何をするか：最終的に使う設定を1行で記録
+            logger.info(f"zr_cfg_normalized {asdict(c)}")  # 何をするか：最終的に使う設定を1行で記録
         except Exception:
             logger.exception("zr_cfg_log_error")  # 何をするか：ログ化に失敗しても戦略は継続
 
@@ -166,7 +163,10 @@ class ZeroReopenPop(StrategyBase):
         """【関数】意思決定ログ：何をするか：判断理由と主要パラメータを1行で記録する"""
         try:
             payload = " ".join(f"{k}={v}" for k, v in fields.items())
-            logger.info("zr_decision reason=%s %s", reason, payload)
+            msg = f"zr_decision reason={reason}"
+            if payload:
+                msg = f"{msg} {payload}"
+            logger.info(msg)
         except Exception:
             logger.exception("zr_decision_log_error")
 


### PR DESCRIPTION
## Summary
- allow ZeroReopenPop to emit through loguru so its messages appear in configured sinks
- add configuration knobs for the shared run log and optional per-strategy text logs
- initialize loguru sinks for both paper and live execution paths using the configured templates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c4f5291883298f6f1e3dcf93f94a